### PR TITLE
Unsafe IO for keys, elems, toList

### DIFF
--- a/Data/Judy.hsc
+++ b/Data/Judy.hsc
@@ -520,6 +520,18 @@ findMax m = do
 ------------------------------------------------------------------------
 
 -- | Return all keys of the map, /lazily/, in ascending order.
+--
+-- Warning: This function is not safe. You /must/ fully evaluate the list (e.g.
+-- by consuming it in some strict function) before making any modifications to
+-- the array. For example,
+--
+-- >>> j <- J.new :: IO (J.JudyL Int)
+-- >>> J.insert 0 10 j
+-- >>> l <- J.keys j
+-- >>> J.insert 1 11 j
+-- >>> l
+-- [0,...(garbage output)
+--
 keys :: JudyL a -> IO [Key]
 keys m = do
 #if !defined(UNSAFE)
@@ -567,6 +579,9 @@ keys m = do
 ------------------------------------------------------------------------
 
 -- | Return keys and values of the map, /lazily/, in ascending order.
+--
+-- Warning: This function is not safe. See 'keys'.
+--
 toList :: JE a => JudyL a -> IO [(Key,a)]
 toList m = do
 #if !defined(UNSAFE)
@@ -615,6 +630,9 @@ toList m = do
 
 
 -- | Return all elems of the map, /lazily/, in ascending order.
+--
+-- Warning: This function is not safe. See 'keys'.
+--
 elems :: JE a => JudyL a -> IO [a]
 elems m = do
 #if !defined(UNSAFE)

--- a/tests/Data/JudySpec.hs
+++ b/tests/Data/JudySpec.hs
@@ -72,3 +72,36 @@ spec = describe "Data.Judy" $ do
       length norepeatResults `shouldBe` length noRepeats
       repeatResults `shouldSatisfy` all (== Just (-1))
       norepeatResults `shouldSatisfy` all (\(Just a) -> a >= 0)
+
+  it "should return keys from the array state at the point `keys` was called" $ do
+    property $ \(k1, k2, v1::Int, v2::Int) -> do
+      j <- J.new :: IO (J.JudyL Int)
+      J.insert k1 v1 j
+      l <- J.keys j
+      J.insert k2 v2 j
+
+      l == [k1] `shouldBe` True
+        -- This was done instead of the more natural
+        --
+        -- > l `shouldBe` [k1]
+        --
+        -- because list l might be extremely long; using `==` allows for lazy
+        -- comparison.
+
+  it "should return elements from the array state at the point `elems` was called" $ do
+    property $ \(k1, k2, v1::Int, v2::Int) -> do
+      j <- J.new :: IO (J.JudyL Int)
+      J.insert k1 v1 j
+      l <- J.elems j
+      J.insert k2 v2 j
+
+      l == [v1] `shouldBe` True
+
+  it "should return key-value pairs from the array state at the point `toList` was called" $ do
+    property $ \(k1, k2, v1::Int, v2::Int) -> do
+      j <- J.new :: IO (J.JudyL Int)
+      J.insert k1 v1 j
+      l <- J.toList j
+      J.insert k2 v2 j
+
+      l == [(k1, v1)] `shouldBe` True


### PR DESCRIPTION
`unsafeInterleaveIO` in the functions `keys`, `elems` and `toList` is actually unsafe.

```
>>> j <- J.new :: IO (J.JudyL Int)
>>> J.insert 0 10 j
>>> l <- J.keys j
>>> J.insert 1 11 j
>>> l
[0,...(garbage output)
```

I'm not sure how to solve this problem. I've just added some warnings to the documentation in this pull request.

The only thing I can come up with is to ask the user to provide a function of type `[(k, v)] -> IO b` and fully evaluating `b`, so that all lazy evaluation can be done while holding the mutex lock. However, it sounds terribly inelegant. Moreover, one has to manually ensure that the array is not referenced in that function, otherwise deadlock will result.

Having said all that, please don't remove `toList`; serialising the array to file would be a nightmare.

Arthur
