### PR TITLE
Fix test suite entry point

### DIFF
--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -4,5 +4,5 @@ import qualified Data.JudySpec
 import           Test.Hspec   (hspec)
 
 main :: IO ()
--- Keep this explicit list in sync with any future *Spec modules.
+-- Data.JudySpec is currently the only *Spec module under tests/.
 main = hspec Data.JudySpec.spec

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,2 +1,7 @@
--- file test/Spec.hs
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+module Main where
+
+import qualified Data.JudySpec
+import           Test.Hspec   (hspec)
+
+main :: IO ()
+main = hspec Data.JudySpec.spec

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -4,4 +4,5 @@ import qualified Data.JudySpec
 import           Test.Hspec   (hspec)
 
 main :: IO ()
+-- Keep this explicit list in sync with any future *Spec modules.
 main = hspec Data.JudySpec.spec


### PR DESCRIPTION
## Summary
- replace the hspec-discover preprocessor entry point with an explicit Hspec main

## Why
Modern Cabal/GHC builds fail the test suite because `hspec-discover` is invoked by `OPTIONS_GHC` but is not declared as a build tool. An explicit test main avoids the undeclared executable while preserving the same discovered spec set.

## Validation
- cabal test --extra-include-dirs=/tmp/judy-libjudy-dev/root/usr/include --extra-lib-dirs=/tmp/judy-libjudy-dev/root/usr/lib/x86_64-linux-gnu
