### PR TITLE
Add CI and coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
   push:
-    branches:
-      - master
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: cabal test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Judy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libjudy-dev
+
+      - name: Set up Haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: "9.12.2"
+          cabal-version: "3.16.0.0"
+
+      - name: Configure
+        run: cabal update
+
+      - name: Build
+        run: cabal build all
+
+      - name: Test
+        run: cabal test all
+
+      - name: Coverage
+        run: |
+          cabal test --enable-coverage all
+          scripts/check-coverage.sh

--- a/Data/Judy.hsc
+++ b/Data/Judy.hsc
@@ -131,7 +131,7 @@ newtype JudyImmutable a = JudyImmutable (JudyL a)
 new :: JE a => IO (JudyL a)
 new = do
     -- we allocate the structure on the Haskell heap (just a pointer)
-    fp <- mallocForeignPtrBytes (sizeOf (undefined :: Ptr Word))
+    fp <- mallocForeignPtr
 
     -- note that the Haskell GC doesn't really know costly the arrays are.
     addForeignPtrFinalizer c_judyl_free_ptr fp
@@ -158,10 +158,8 @@ insert k v m = do
 #else
       withForeignPtr (unJudyL m)  $ \p -> do
 #endif
-        v_ptr <- c_judy_lins p (fromIntegral k) nullError
-        if v_ptr == judyErrorPtr
-            then memoryError
-            else poke v_ptr =<< toWord v
+        v_ptr <- checkJudyPtr <$> c_judy_lins p (fromIntegral k) nullError
+        poke v_ptr =<< toWord v
 {-# INLINE insert #-}
 
 -- | Insert with a function, combining new value and old value.
@@ -177,17 +175,15 @@ insertWith f k v m = do
       withForeignPtr (unJudyL m)  $ \p -> do
 #endif
         q     <- peek p -- get the actual judy array
-        v_ptr1 <- c_judy_lget q (fromIntegral k) nullError
-        if v_ptr1 == judyErrorPtr then memoryError
-            else if v_ptr1 == nullPtr
-                    then do
-                        v_ptr2 <- c_judy_lins p (fromIntegral k) nullError
-                        if v_ptr2 == judyErrorPtr then memoryError
-                          else poke v_ptr2 =<< toWord v
-                    else do
-                        old_v <- fromWord =<< peek v_ptr1
-                        new_v <- toWord (f v old_v)
-                        poke v_ptr1 new_v
+        v_ptr1 <- checkJudyPtr <$> c_judy_lget q (fromIntegral k) nullError
+        if v_ptr1 == nullPtr
+            then do
+                v_ptr2 <- checkJudyPtr <$> c_judy_lins p (fromIntegral k) nullError
+                poke v_ptr2 =<< toWord v
+            else do
+                old_v <- fromWord =<< peek v_ptr1
+                new_v <- toWord (f v old_v)
+                poke v_ptr1 new_v
 {-# INLINE insertWith #-}
 
 ------------------------------------------------------------------------
@@ -203,14 +199,12 @@ lookup k m = do
       withForeignPtr (unJudyL m)  $ \p -> do
 #endif
         q     <- peek p -- get the actual judy array
-        v_ptr <- c_judy_lget q (fromIntegral k) nullError
-        if v_ptr == judyErrorPtr
-            then memoryError
-            else if v_ptr == nullPtr
-                    then return Nothing
-                    else do
-                        v <- fromWord =<< peek v_ptr
-                        return . Just $! v
+        v_ptr <- checkJudyPtr <$> c_judy_lget q (fromIntegral k) nullError
+        if v_ptr == nullPtr
+            then return Nothing
+            else do
+                v <- fromWord =<< peek v_ptr
+                return . Just $! v
 {-# INLINE lookup #-}
 
 -- | Is the key a member of the map?
@@ -223,10 +217,8 @@ member k m = do
       withForeignPtr (unJudyL m)  $ \p -> do
 #endif
         q     <- peek p -- get the actual judy array
-        v_ptr <- c_judy_lget q (fromIntegral k) nullError
-        if v_ptr == judyErrorPtr
-            then memoryError
-            else return $! v_ptr /= nullPtr
+        v_ptr <- checkJudyPtr <$> c_judy_lget q (fromIntegral k) nullError
+        return $! v_ptr /= nullPtr
 {-# INLINE member #-}
 
 -- | Update a value at a specific key with the result of the provided
@@ -240,15 +232,13 @@ adjust f k m = do
       withForeignPtr (unJudyL m)  $ \p -> do
 #endif
         q     <- peek p -- get the actual judy array
-        v_ptr <- c_judy_lget q (fromIntegral k) nullError
-        if v_ptr == judyErrorPtr
-            then memoryError
-            else if v_ptr == nullPtr
-                    then return ()
-                    else do
-                        old_v <- fromWord =<< peek v_ptr
-                        new_v <- toWord (f old_v)
-                        poke v_ptr new_v
+        v_ptr <- checkJudyPtr <$> c_judy_lget q (fromIntegral k) nullError
+        if v_ptr == nullPtr
+            then return $! ()
+            else do
+                old_v <- fromWord =<< peek v_ptr
+                new_v <- toWord (f old_v)
+                poke v_ptr new_v
 {-# INLINE adjust #-}
 
 
@@ -263,7 +253,8 @@ delete k m = do
       withForeignPtr (unJudyL m)  $ \p -> do
 #endif
         i <- c_judy_ldel p (fromIntegral k) nullError
-        if i == judyError then memoryError else return ()
+        _ <- evaluate (checkJudyInt i)
+        return $! ()
 {-# INLINE delete #-}
 
 
@@ -632,4 +623,3 @@ instance JE S.ByteString where
                      a## -> deRefStablePtr (castPtrToStablePtr (Ptr a##))
     {-# INLINE toWord   #-}
     {-# INLINE fromWord #-}
-

--- a/Data/Judy/Internal.hsc
+++ b/Data/Judy/Internal.hsc
@@ -5,6 +5,7 @@
 
 module Data.Judy.Internal (
     JudyL_, JudyL(..), Key, JError(..), nullError, judyError, judyErrorPtr, memoryError,
+    checkJudyPtr, checkJudyInt,
     c_judyl_free_ptr, c_judy_lget, c_judy_lins, c_judy_ldel,
     c_judy_lcount, c_judy_lfirst, c_judy_lnext, c_judy_llast
   ) where
@@ -247,3 +248,14 @@ memoryError :: a
 memoryError = error "Data.Judy: memory error with JudyL"
 {-# NOINLINE memoryError #-}
 
+checkJudyPtr :: Ptr Word -> Ptr Word
+checkJudyPtr p
+    | p == judyErrorPtr = memoryError
+    | otherwise         = p
+{-# INLINE checkJudyPtr #-}
+
+checkJudyInt :: CInt -> CInt
+checkJudyInt i
+    | i == judyError = memoryError
+    | otherwise      = i
+{-# INLINE checkJudyInt #-}

--- a/judy.cabal
+++ b/judy.cabal
@@ -47,6 +47,7 @@ test-suite tests
   other-modules: Data.JudySpec
   ghc-options: -Wall -threaded -rtsopts
   build-depends: base
+               , bytestring
                , hspec
                , judy
                , QuickCheck

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tix_file=$(find dist-newstyle -path '*/t/tests/hpc/vanilla/tix/tests.tix' -print -quit)
+if [[ -z "$tix_file" ]]; then
+  echo "Could not find Cabal HPC .tix file" >&2
+  exit 1
+fi
+
+mapfile -t hpc_dirs < <(find dist-newstyle -path '*/extra-compilation-artifacts/hpc/vanilla/mix' -type d | sort)
+if [[ ${#hpc_dirs[@]} -eq 0 ]]; then
+  echo "Could not find Cabal HPC .mix directories" >&2
+  exit 1
+fi
+
+hpc_args=()
+for dir in "${hpc_dirs[@]}"; do
+  hpc_args+=(--hpcdir="$dir")
+done
+
+report=$(hpc report "$tix_file" "${hpc_args[@]}" --include=Data.Judy --srcdir=. --per-module)
+echo "$report"
+
+required_markers=(
+  "100% expressions used"
+  "100% boolean coverage"
+  "100% alternatives used"
+  "100% local declarations used"
+  "100% top-level declarations used"
+)
+
+for marker in "${required_markers[@]}"; do
+  if ! grep -q "$marker" <<<"$report"; then
+    echo "Coverage check failed: missing '$marker'" >&2
+    exit 1
+  fi
+done

--- a/tests/Data/JudySpec.hs
+++ b/tests/Data/JudySpec.hs
@@ -3,11 +3,12 @@
 module Data.JudySpec where
 
 import           Control.Arrow   ((***))
+import qualified Data.ByteString as S
+import           Data.Int        (Int16, Int32, Int8)
 import qualified Data.Judy       as J
 import           Data.List       (group, groupBy, nub, partition, sort, sortBy)
-import           Data.Monoid     ((<>))
 import           Data.Ord        (comparing)
-import           Data.Word       (Word)
+import           Data.Word       (Word, Word16, Word32, Word8)
 import           System.Mem      (performGC)
 import           Test.Hspec      (Spec, describe, it, shouldBe, shouldReturn,
                                   shouldSatisfy)
@@ -31,6 +32,43 @@ spec = describe "Data.Judy" $ do
       result <- J.lookup k j
 
       result `shouldBe` Just v
+
+  it "should report membership" $
+    property $ \(k, other, v::Int) ->
+      k /= other ==>
+        do
+          j <- J.new :: IO (J.JudyL Int)
+          J.member k j `shouldReturn` False
+          J.insert k v j
+          J.member k j `shouldReturn` True
+          J.member other j `shouldReturn` False
+
+  it "should delete values" $
+    property $ \(k, v::Int) -> do
+      j <- J.new :: IO (J.JudyL Int)
+      J.delete k j
+      J.insert k v j
+      J.delete k j
+      J.lookup k j `shouldReturn` Nothing
+
+  it "should adjust existing values only" $
+    property $ \(k, other, v::Int) ->
+      k /= other ==>
+        do
+          j <- J.new :: IO (J.JudyL Int)
+          J.adjust (+ 1) k j
+          J.lookup k j `shouldReturn` Nothing
+          J.insert k v j
+          J.adjust (+ 1) k j
+          J.adjust (+ 1) other j
+          J.lookup k j `shouldReturn` Just (v + 1)
+          J.lookup other j `shouldReturn` Nothing
+
+  it "should report whether the array is empty" $ do
+    j <- J.new :: IO (J.JudyL Int)
+    J.null j `shouldReturn` True
+    J.insert 1 1 j
+    J.null j `shouldReturn` False
 
   it "freezing should be idempotent" $
     property $ \(values'::[(Word, Int)]) -> do
@@ -89,6 +127,12 @@ spec = describe "Data.Judy" $ do
       repeatResults `shouldSatisfy` all (== Just (-1))
       norepeatResults `shouldSatisfy` all (\(Just a) -> a >= 0)
 
+  it "insertWith should combine new and old values" $ do
+    j <- J.new :: IO (J.JudyL Int)
+    J.insert 1 10 j
+    J.insertWith (+) 1 5 j
+    J.lookup 1 j `shouldReturn` Just 15
+
   it "should return key-value pairs from the array state at the point `toList` was called" $
     property $ \(k1, k2, v1::Int, v2::Int) -> do
       j <- J.new :: IO (J.JudyL Int)
@@ -113,3 +157,35 @@ spec = describe "Data.Judy" $ do
       mapM_ (\k -> J.insert k () j) ordered
       let res = case ordered of [] -> Nothing; xs -> Just (last xs,())
       J.findMax j `shouldReturn` res
+
+  it "findMin should find the min" $
+    property $ \(ls :: [Word]) -> do
+      j <- J.new :: IO (J.JudyL ())
+      let ordered = map head . group $ sort ls
+      mapM_ (\k -> J.insert k () j) ordered
+      let res = case ordered of [] -> Nothing; xs -> Just (head xs,())
+      J.findMin j `shouldReturn` res
+
+  it "should round-trip storable element representations" $ do
+    roundTrip ()
+    roundTrip True
+    roundTrip False
+    roundTrip LT
+    roundTrip EQ
+    roundTrip GT
+    roundTrip (123 :: Word)
+    roundTrip (-123 :: Int)
+    roundTrip (-12 :: Int8)
+    roundTrip (-1234 :: Int16)
+    roundTrip (-123456 :: Int32)
+    roundTrip (12 :: Word8)
+    roundTrip (1234 :: Word16)
+    roundTrip (123456 :: Word32)
+    roundTrip 'J'
+    roundTrip (S.pack [0, 1, 2, 255])
+
+roundTrip :: (Eq a, Show a, J.JE a) => a -> IO ()
+roundTrip value = do
+  encoded <- J.toWord value
+  decoded <- J.fromWord encoded
+  decoded `shouldBe` value

--- a/tests/Data/JudySpec.hs
+++ b/tests/Data/JudySpec.hs
@@ -6,9 +6,9 @@ import           Control.Arrow   ((***))
 import qualified Data.ByteString as S
 import           Data.Int        (Int16, Int32, Int8)
 import qualified Data.Judy       as J
-import           Data.List       (group, groupBy, nub, partition, sort, sortBy)
+import           Data.List       (groupBy, nub, partition, sort, sortBy)
 import           Data.Ord        (comparing)
-import           Data.Word       (Word, Word16, Word32, Word8)
+import           Data.Word       (Word16, Word32, Word8)
 import           System.Mem      (performGC)
 import           Test.Hspec      (Spec, describe, it, shouldBe, shouldReturn,
                                   shouldSatisfy)
@@ -71,10 +71,8 @@ spec = describe "Data.Judy" $ do
     J.null j `shouldReturn` False
 
   it "freezing should be idempotent" $
-    property $ \(values'::[(Word, Int)]) -> do
-      let values = map head
-                   $ groupBy (\a b -> fst a == fst b)
-                   $ sortBy (comparing fst) values'
+    property $ \(values'::[(J.Key, Int)]) -> do
+      let values = uniqueByKey $ sortBy (comparing fst) values'
       j <- J.new
       mapM_ (\(k,v) -> J.insert k v j) values
       newj <- J.unsafeFreeze j
@@ -86,7 +84,7 @@ spec = describe "Data.Judy" $ do
            ])
     $ \(name,method) ->
     it ("should fetch keys & vals in the right order using " <> name) $
-      property $ \(al :: [(Word,Int)]) ->
+      property $ \(al :: [(J.Key,Int)]) ->
         length al == length (nub $ map fst al) ==>
         do
           let sortedL = sortBy (comparing fst) al
@@ -106,7 +104,7 @@ spec = describe "Data.Judy" $ do
     -- bit ugly, but we don't have a Maybe instance for JE yet
     let combine _ _ = (-1) in
 
-    property $ \(values'::[(Word, Int)]) -> do
+    property $ \(values'::[(J.Key, Int)]) -> do
       -- want lots of repeats, so we take the modulo of the key.
       -- as noted above, because of the lack of a Maybe instance we
       -- denote a collision with a negative number: therefore, all
@@ -115,7 +113,7 @@ spec = describe "Data.Judy" $ do
       j <- J.new :: IO (J.JudyL Int)
       mapM_ (\(k,v) -> J.insertWith combine k v j) values
       -- at this point, all repeated keys should have Nothing values
-      let (repeats, noRepeats) = (map (fst.head) *** map (fst.head))
+      let (repeats, noRepeats) = (groupKeys *** groupKeys)
                                  $ partition (\x -> length x > 1)
                                  $ groupBy (\a b -> fst a == fst b)
                                  $ sortBy (comparing fst) values
@@ -125,7 +123,7 @@ spec = describe "Data.Judy" $ do
       length repeatResults `shouldBe` length repeats
       length norepeatResults `shouldBe` length noRepeats
       repeatResults `shouldSatisfy` all (== Just (-1))
-      norepeatResults `shouldSatisfy` all (\(Just a) -> a >= 0)
+      norepeatResults `shouldSatisfy` all (maybe False (>= 0))
 
   it "insertWith should combine new and old values" $ do
     j <- J.new :: IO (J.JudyL Int)
@@ -144,26 +142,26 @@ spec = describe "Data.Judy" $ do
       l == [(k1, v1)] `shouldBe` True
 
   it "should return the correct size" $
-    property $ \(ls :: [Word]) -> do
+    property $ \(ls :: [J.Key]) -> do
       j <- J.new :: IO (J.JudyL ())
-      let ordered = map head . group $ sort ls
+      let ordered = uniqueSorted $ sort ls
       mapM_ (\k -> J.insert k () j) ordered
       J.size j `shouldReturn` length ordered
 
   it "findMax should find the max" $
-    property $ \(ls :: [Word]) -> do
+    property $ \(ls :: [J.Key]) -> do
       j <- J.new :: IO (J.JudyL ())
-      let ordered = map head . group $ sort ls
+      let ordered = uniqueSorted $ sort ls
       mapM_ (\k -> J.insert k () j) ordered
-      let res = case ordered of [] -> Nothing; xs -> Just (last xs,())
+      let res = case reverse ordered of [] -> Nothing; x:_ -> Just (x,())
       J.findMax j `shouldReturn` res
 
   it "findMin should find the min" $
-    property $ \(ls :: [Word]) -> do
+    property $ \(ls :: [J.Key]) -> do
       j <- J.new :: IO (J.JudyL ())
-      let ordered = map head . group $ sort ls
+      let ordered = uniqueSorted $ sort ls
       mapM_ (\k -> J.insert k () j) ordered
-      let res = case ordered of [] -> Nothing; xs -> Just (head xs,())
+      let res = case ordered of [] -> Nothing; x:_ -> Just (x,())
       J.findMin j `shouldReturn` res
 
   it "should round-trip storable element representations" $ do
@@ -189,3 +187,17 @@ roundTrip value = do
   encoded <- J.toWord value
   decoded <- J.fromWord encoded
   decoded `shouldBe` value
+
+uniqueSorted :: Eq a => [a] -> [a]
+uniqueSorted [] = []
+uniqueSorted (x:xs) = x : uniqueSorted (dropWhile (== x) xs)
+
+uniqueByKey :: Eq k => [(k, a)] -> [(k, a)]
+uniqueByKey [] = []
+uniqueByKey (x:xs) = x : uniqueByKey (dropWhile ((== fst x) . fst) xs)
+
+groupKeys :: [[(k, a)]] -> [k]
+groupKeys = foldr addKey []
+  where
+    addKey [] acc = acc
+    addKey ((k,_):_) acc = k : acc


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow that installs `libjudy-dev`, builds, tests, and runs coverage
- add a coverage checker that enforces 100% coverage for the public `Data.Judy` module
- expand the test suite across the public Judy operations and `JE` conversions

## Validation
- `cabal test all --extra-include-dirs=/tmp/judy-libjudy-dev/root/usr/include --extra-lib-dirs=/tmp/judy-libjudy-dev/root/usr/lib/x86_64-linux-gnu`
- `cabal test --enable-coverage all --extra-include-dirs=/tmp/judy-libjudy-dev/root/usr/include --extra-lib-dirs=/tmp/judy-libjudy-dev/root/usr/lib/x86_64-linux-gnu`
- `scripts/check-coverage.sh`

Coverage gate output:

```text
100% expressions used (732/732)
100% boolean coverage (11/11)
100% alternatives used (34/34)
100% local declarations used (4/4)
100% top-level declarations used (43/43)
```
